### PR TITLE
Update dataTables.responsive.js

### DIFF
--- a/js/dataTables.responsive.js
+++ b/js/dataTables.responsive.js
@@ -627,6 +627,8 @@ $.extend( Responsive.prototype, {
 		var that = this;
 		var dt = this.s.dt;
 
+		this.s.rowIdxDisplayedModal = rowIdx;
+
 		return $.map( this.s.columns, function( col, i ) {
 			if ( col.never ) {
 				return;
@@ -673,9 +675,9 @@ $.extend( Responsive.prototype, {
 		var dt = this.s.dt;
 
 		dt.rows( {page: 'current'} ).iterator( 'row', function ( settings, idx ) {
-			var row = dt.row( idx );
-
-			that._detailsDisplay( dt.row( idx ), true );
+			if (undefined !== that.s.rowIdxDisplayedModal && that.s.rowIdxDisplayedModal[0] === idx) {
+				that._detailsDisplay( dt.row( idx ), true );
+			}
 		} );
 	},
 
@@ -1002,9 +1004,17 @@ Responsive.display = {
 				} );
 			}
 			else {
-				$('div.dtr-modal-content')
+				var modalContent = $('div.dtr-modal-content');
+
+				modalContent
 					.empty()
 					.append( render() );
+
+				if ( options && options.header ) {
+					modalContent.prepend(
+					    '<h2>'+options.header( row )+'</h2>'
+					);
+				}
 			}
 		};
 	}


### PR DESCRIPTION
Fix update modal on resize:
- put back header (remove by empty() )
- only call _detailsDisplay for the row displayed in _redrawChildren
